### PR TITLE
Change function name to not enqueue admin assets frontend

### DIFF
--- a/class-grid.php
+++ b/class-grid.php
@@ -33,18 +33,18 @@ if ( ! class_exists( '\\Dekode\\Hogan\\Grid' ) && class_exists( '\\Dekode\\Hogan
 		 */
 		public function __construct() {
 
-			$this->label = __( 'Card grid', 'hogan-grid' );
+			$this->label    = __( 'Card grid', 'hogan-grid' );
 			$this->template = __DIR__ . '/assets/template.php';
 
-			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
 
 			parent::__construct();
 		}
 
 		/**
-		 * Enqueue module assets
+		 * Enqueue module admin assets
 		 */
-		public function enqueue_assets() {
+		public function enqueue_admin_assets() {
 			$_version = defined( 'SCRIPT_DEBUG' ) && true === SCRIPT_DEBUG ? time() : false;
 			wp_enqueue_style( 'grid-admin-style', plugins_url( '/assets/admin-style.css', __FILE__ ), [], $_version );
 		}


### PR DESCRIPTION
After https://github.com/DekodeInteraktiv/hogan-core/pull/32 was merged we need to change we need to change the admin enqueue assets function name. `enqueue_assets` will automagic enqueue assets frontend when modules is used.