### PR TITLE
Make sure dynamic posts doesn't show same card multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Added filter `hogan/module/grid/template/text-align` to change text align classname.
+- Make sure dynamic posts doesn't show same card multiple times.
 
 ## 1.1.2
 - Styled meta info added in [DekodeInteraktiv/savage-cards#31](https://github.com/DekodeInteraktiv/savage-cards/pull/31)

--- a/class-grid.php
+++ b/class-grid.php
@@ -224,18 +224,20 @@ if ( ! class_exists( '\\Dekode\\Hogan\\Grid' ) && class_exists( '\\Dekode\\Hogan
 				return '';
 			}
 
-			$cards = [];
+			$cards         = [];
+			$fetched_posts = [];
 
 			foreach ( $data as $group ) {
 
 				switch ( $group['acf_fc_layout'] ) {
 
 					case 'static_content':
-						foreach ( $group['posts_list'] as $card ) {
+						foreach ( $group['posts_list'] as $post_id ) {
+							$fetched_posts[] = $post_id;
 
 							$cards[] = [
-								'id'   => $card,
-								'type' => get_post_type( $card ),
+								'id'   => $post_id,
+								'type' => get_post_type( $post_id ),
 								'size' => $group['card_style'],
 							];
 						}
@@ -246,12 +248,15 @@ if ( ! class_exists( '\\Dekode\\Hogan\\Grid' ) && class_exists( '\\Dekode\\Hogan
 							'fields'         => 'ids',
 							'post_type'      => $group['card_content_type'],
 							'posts_per_page' => $group['number_of_items'],
+							'post__not_in'   => $fetched_posts,
 						] );
 
 						if ( $cards_query->have_posts() ) {
-							foreach ( $cards_query->posts as $card ) {
+							foreach ( $cards_query->posts as $post_id ) {
+								$fetched_posts[] = $post_id;
+
 								$cards[] = [
-									'id'   => $card,
+									'id'   => $post_id,
 									'type' => $group['card_content_type'],
 									'size' => $group['card_style'],
 								];

--- a/class-grid.php
+++ b/class-grid.php
@@ -36,6 +36,13 @@ if ( ! class_exists( '\\Dekode\\Hogan\\Grid' ) && class_exists( '\\Dekode\\Hogan
 		public $text_align;
 
 		/**
+		 * Fetched posts on page
+		 *
+		 * @var array
+		 */
+		public $fetched_posts = [];
+
+		/**
 		 * Module constructor.
 		 */
 		public function __construct() {
@@ -224,8 +231,7 @@ if ( ! class_exists( '\\Dekode\\Hogan\\Grid' ) && class_exists( '\\Dekode\\Hogan
 				return '';
 			}
 
-			$cards         = [];
-			$fetched_posts = [];
+			$cards = [];
 
 			foreach ( $data as $group ) {
 
@@ -233,7 +239,7 @@ if ( ! class_exists( '\\Dekode\\Hogan\\Grid' ) && class_exists( '\\Dekode\\Hogan
 
 					case 'static_content':
 						foreach ( $group['posts_list'] as $post_id ) {
-							$fetched_posts[] = $post_id;
+							$this->fetched_posts[] = $post_id;
 
 							$cards[] = [
 								'id'   => $post_id,
@@ -248,12 +254,12 @@ if ( ! class_exists( '\\Dekode\\Hogan\\Grid' ) && class_exists( '\\Dekode\\Hogan
 							'fields'         => 'ids',
 							'post_type'      => $group['card_content_type'],
 							'posts_per_page' => $group['number_of_items'],
-							'post__not_in'   => $fetched_posts,
+							'post__not_in'   => $this->fetched_posts,
 						] );
 
 						if ( $cards_query->have_posts() ) {
 							foreach ( $cards_query->posts as $post_id ) {
-								$fetched_posts[] = $post_id;
+								$this->fetched_posts[] = $post_id;
 
 								$cards[] = [
 									'id'   => $post_id,


### PR DESCRIPTION
To not show the same card multiple times we need to send in already fetched cards to wp_query when getting dynamic cards.