### PR TITLE
Allow bool in `structure_card_data` and return array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-# 1.1.6
+## Unreleased
+- Fixed a fatal type error bug when so cards i selected backend. [#36](https://github.com/DekodeInteraktiv/hogan-grid/issues/36)
+
+## 1.1.6
 - Added `hogan/module/grid/theme` filter. With this you can now add section theme classname.
 
 ## 1.1.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Fixed a fatal type error bug when no cards i selected backend. [#36](https://github.com/DekodeInteraktiv/hogan-grid/issues/36)
+- Fixed a fatal type error bug when no cards is selected backend. [#36](https://github.com/DekodeInteraktiv/hogan-grid/issues/36)
 
 ## 1.1.6
 - Added `hogan/module/grid/theme` filter. With this you can now add section theme classname.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Fixed a fatal type error bug when so cards i selected backend. [#36](https://github.com/DekodeInteraktiv/hogan-grid/issues/36)
+- Fixed a fatal type error bug when no cards i selected backend. [#36](https://github.com/DekodeInteraktiv/hogan-grid/issues/36)
 
 ## 1.1.6
 - Added `hogan/module/grid/theme` filter. With this you can now add section theme classname.

--- a/class-grid.php
+++ b/class-grid.php
@@ -302,13 +302,13 @@ if ( ! class_exists( '\\Dekode\\Hogan\\Grid' ) && class_exists( '\\Dekode\\Hogan
 		/**
 		 * Get card layouts
 		 *
-		 * @param array $data ACF layouts.
+		 * @param bool|array $data ACF layouts.
 		 * @return array Cards collection
 		 */
-		public function structure_card_data( array $data ) : array {
+		public function structure_card_data( $data ) : array {
 
 			if ( empty( $data ) ) {
-				return '';
+				return [];
 			}
 
 			$cards = [];


### PR DESCRIPTION
If you insert a grid module without any cards `flex_grid` value is a `bool`. We need to remove the type hint on the `structure_card_data` function to allow both `array` and `bool`

Also return a empty array if no data.

![image](https://user-images.githubusercontent.com/1415747/37703122-e95799e2-2cf4-11e8-8cef-46901cb22e45.png)
